### PR TITLE
fix: update vercel config.

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,5 @@
 {
   "cleanUrls": true,
   "installCommand": "bun install",
-  "buildCommand": "bunx --bun next build",
-  "outputDirectory": ".next",
-  "functions": {
-    "api/**": {
-      "runtime": "edge"
-    }
-  }
+  "buildCommand": "bunx --bun next build"
 }


### PR DESCRIPTION
Edited `vercel.json` to remove the legacy “functions” runtime block that was set to "edge" (which Vercel now expects as a versioned runtime string). 

Next.js 13+ supports Edge via `export const runtime = 'edge'` in each API route, which you already use. Keeping the “functions” entry with an unversioned runtime triggers the Vercel error.