### PR TITLE
fix: katana APYs

### DIFF
--- a/src/lib/og/apy.ts
+++ b/src/lib/og/apy.ts
@@ -1,7 +1,12 @@
 import { YBOLD_VAULT_ADDRESS } from './data'
 
 export function calculateKatanaAPY(extra: Record<string, number>): number {
-  const { katanaRewardsAPR: _legacy, ...rest } = extra || {}
+  const {
+    katanaRewardsAPR: _legacy,
+    katanaBonusAPY: _bonus,
+    steerPointsPerDollar: _points,
+    ...rest
+  } = extra || {}
   return Object.values(rest).reduce(
     (s, v) => s + (typeof v === 'number' ? v : 0),
     0


### PR DESCRIPTION
Updates the function that calculates Katana APYs to ignore old bonuses as well as the steer points