### PR TITLE
update OG for katana

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A Vercel-ready microservice to generate Open Graph (OG) social images for Yearn 
 
 ## Env
 
-- `YDAEMON_BASE_URI` e.g. `https://ydaemon.yearn.fi` (required for vault route)
-- `BASE_YEARN_ASSETS_URI` e.g. `cdn.jsdelivr.net` (vault logos)
-- `KATANA_APR_SERVICE_API` optional for Katana chain
+- `KONG_REST_URL` optional, defaults to `https://kong.yearn.fi/api/rest` (vault snapshots)
+- `BASE_YEARN_ASSETS_URI` e.g. `https://cdn.jsdelivr.net/gh/yearn/tokenassets@main` (vault logos)
+- `KATANA_APR_SERVICE_API` optional Katana APR fallback when Kong snapshots do not include Katana reward fields
 - `YVUSD_APR_SERVICE_API` optional for yvUSD APR overlay; defaults to `https://yearn-yvusd-apr-service.vercel.app/api/aprs`
 - `ALLOWED_HOSTS` optional comma list for font origin resolution (defaults to yearn.fi and localhost)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A Vercel-ready microservice to generate Open Graph (OG) social images for Yearn 
 - `KONG_REST_URL` optional, defaults to `https://kong.yearn.fi/api/rest` (vault snapshots)
 - `BASE_YEARN_ASSETS_URI` e.g. `https://cdn.jsdelivr.net/gh/yearn/tokenassets@main` (vault logos)
 - `KATANA_APR_SERVICE_API` optional Katana APR fallback when Kong snapshots do not include Katana reward fields
+- `YDAEMON_BASE_URI` optional override for the yDaemon base URL used for vault data
 - `YVUSD_APR_SERVICE_API` optional for yvUSD APR overlay; defaults to `https://yearn-yvusd-apr-service.vercel.app/api/aprs`
 - `ALLOWED_HOSTS` optional comma list for font origin resolution (defaults to yearn.fi and localhost)
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/src/lib/og/apy.test.ts
+++ b/src/lib/og/apy.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  calculateEstimatedAPY,
+  calculateHistoricalAPY,
+  getKatanaEstimatedApyBreakdown,
+  getKatanaHistoricalApyBreakdown,
+  hasKatanaRewardAprData,
+} from './apy'
+
+function makeVault(overrides: Record<string, any> = {}) {
+  return {
+    address: '0x0000000000000000000000000000000000000001',
+    chainID: 747474,
+    apr: {
+      netAPR: 0.03,
+      extra: {},
+      points: {
+        monthAgo: 0.02,
+        weekAgo: 0.03,
+      },
+      forwardAPR: {
+        netAPR: 0.068,
+      },
+    },
+    ...overrides,
+  }
+}
+
+describe('Katana OG APY helpers', () => {
+  test('detects explicit Katana reward fields but ignores steer points', () => {
+    expect(
+      hasKatanaRewardAprData(
+        makeVault({
+          apr: {
+            extra: {
+              steerPointsPerDollar: 9.99,
+            },
+          },
+        })
+      )
+    ).toBe(false)
+
+    expect(
+      hasKatanaRewardAprData(
+        makeVault({
+          apr: {
+            extra: {
+              katanaAppRewardsAPR: 0,
+              fixedRateKatanaRewards: 0,
+              steerPointsPerDollar: 9.99,
+            },
+          },
+        })
+      )
+    ).toBe(true)
+  })
+
+  test('uses snapshot Katana reward fields for estimated APY and ignores steer points', () => {
+    const breakdown = getKatanaEstimatedApyBreakdown(
+      makeVault({
+        apr: {
+          netAPR: 0.03,
+          extra: {
+            katanaAppRewardsAPR: 0.0916,
+            fixedRateKatanaRewards: 0.35,
+            steerPointsPerDollar: 0.1883,
+          },
+          points: {
+            monthAgo: 0.02,
+            weekAgo: 0.03,
+          },
+          forwardAPR: {
+            netAPR: 0.068,
+          },
+        },
+      }),
+      undefined
+    )
+    const [estimatedApy, rewardsAPR] = calculateEstimatedAPY(
+      makeVault({
+        apr: {
+          netAPR: 0.03,
+          extra: {
+            katanaAppRewardsAPR: 0.0916,
+            fixedRateKatanaRewards: 0.35,
+            steerPointsPerDollar: 0.1883,
+          },
+          points: {
+            monthAgo: 0.02,
+            weekAgo: 0.03,
+          },
+          forwardAPR: {
+            netAPR: 0.068,
+          },
+        },
+      }),
+      undefined,
+      null
+    )
+
+    expect(breakdown).toEqual({
+      native: 0.068,
+      kat: 0.4416,
+    })
+    expect(estimatedApy).toBeCloseTo(0.5096, 6)
+    expect(rewardsAPR).toBeUndefined()
+  })
+
+  test('calculates Katana 30 day APY from monthAgo plus snapshot reward fields', () => {
+    const breakdown = getKatanaHistoricalApyBreakdown(
+      makeVault({
+        apr: {
+          netAPR: 0.03,
+          extra: {
+            katanaAppRewardsAPR: 0.0916,
+            fixedRateKatanaRewards: 0.35,
+            steerPointsPerDollar: 0.1883,
+          },
+          points: {
+            monthAgo: 0.02,
+            weekAgo: 0.03,
+          },
+          forwardAPR: {
+            netAPR: 0.068,
+          },
+        },
+      }),
+      undefined
+    )
+    const historicalApy = calculateHistoricalAPY(
+      makeVault({
+        apr: {
+          netAPR: 0.03,
+          extra: {
+            katanaAppRewardsAPR: 0.0916,
+            fixedRateKatanaRewards: 0.35,
+            steerPointsPerDollar: 0.1883,
+          },
+          points: {
+            monthAgo: 0.02,
+            weekAgo: 0.03,
+          },
+          forwardAPR: {
+            netAPR: 0.068,
+          },
+        },
+      }),
+      undefined,
+      null
+    )
+
+    expect(breakdown).toEqual({
+      native: 0.02,
+      kat: 0.4416,
+    })
+    expect(historicalApy).toBeCloseTo(0.4616, 6)
+  })
+
+  test('falls back to weekAgo when monthAgo is zero', () => {
+    const historicalApy = calculateHistoricalAPY(
+      makeVault({
+        apr: {
+          netAPR: 0.03,
+          extra: {
+            katanaAppRewardsAPR: 0.0916,
+            fixedRateKatanaRewards: 0.35,
+          },
+          points: {
+            monthAgo: 0,
+            weekAgo: 0.03,
+          },
+          forwardAPR: {
+            netAPR: 0.068,
+          },
+        },
+      }),
+      undefined,
+      null
+    )
+
+    expect(historicalApy).toBeCloseTo(0.4716, 6)
+  })
+
+  test('falls back to legacy Katana APR service reward fields when snapshot fields are absent', () => {
+    const vault = makeVault({
+      apr: {
+        netAPR: 0.03,
+        extra: {
+          steerPointsPerDollar: 100,
+        },
+        points: {
+          monthAgo: 0.02,
+          weekAgo: 0.03,
+        },
+        forwardAPR: {
+          netAPR: 0.04,
+        },
+      },
+    })
+    const katanaAprs = {
+      '0x0000000000000000000000000000000000000001': {
+        apr: {
+          extra: {
+            katanaRewardsAPR: 0.11,
+            FixedRateKatanaRewards: 0.35,
+            steerPointsPerDollar: 100,
+          },
+        },
+      },
+    }
+
+    const [estimatedApy] = calculateEstimatedAPY(vault, katanaAprs, null)
+    const historicalApy = calculateHistoricalAPY(vault, katanaAprs, null)
+
+    expect(estimatedApy).toBeCloseTo(0.5, 6)
+    expect(historicalApy).toBeCloseTo(0.48, 6)
+  })
+
+  test('preserves non-Katana estimated and historical APY behavior', () => {
+    const vault = makeVault({
+      chainID: 1,
+      apr: {
+        netAPR: 0.025,
+        extra: {
+          stakingRewardsAPR: 0.01,
+          gammaRewardAPR: 0.02,
+        },
+        points: {
+          monthAgo: 0.02,
+          weekAgo: 0.01,
+        },
+        forwardAPR: {
+          netAPR: 0.03,
+        },
+      },
+    })
+
+    const [estimatedApy, rewardsAPR] = calculateEstimatedAPY(
+      vault,
+      undefined,
+      null
+    )
+    const historicalApy = calculateHistoricalAPY(vault, undefined, null)
+
+    expect(estimatedApy).toBeCloseTo(0.03, 6)
+    expect(rewardsAPR).toBeCloseTo(0.03, 6)
+    expect(historicalApy).toBeCloseTo(0.02, 6)
+  })
+})

--- a/src/lib/og/apy.ts
+++ b/src/lib/og/apy.ts
@@ -1,4 +1,5 @@
 import { YBOLD_VAULT_ADDRESS } from './data'
+import { toFiniteNumber } from './number'
 
 const KATANA_CHAIN_ID = 747474
 
@@ -10,14 +11,6 @@ type KatanaRewardAprData = {
 export type KatanaApyBreakdown = {
   native: number
   kat: number
-}
-
-function toFiniteNumber(value: unknown): number | undefined {
-  if (value === null || value === undefined || value === '') return undefined
-  const parsed = typeof value === 'string' ? Number(value) : value
-  return typeof parsed === 'number' && Number.isFinite(parsed)
-    ? parsed
-    : undefined
 }
 
 function getKatanaRecordForVault(vault: any, katanaAprs: any | undefined): any {

--- a/src/lib/og/apy.ts
+++ b/src/lib/og/apy.ts
@@ -1,16 +1,130 @@
 import { YBOLD_VAULT_ADDRESS } from './data'
 
-export function calculateKatanaAPY(extra: Record<string, number>): number {
-  const {
-    katanaRewardsAPR: _legacy,
-    katanaBonusAPY: _bonus,
-    steerPointsPerDollar: _points,
-    ...rest
-  } = extra || {}
-  return Object.values(rest).reduce(
-    (s, v) => s + (typeof v === 'number' ? v : 0),
-    0
+const KATANA_CHAIN_ID = 747474
+
+type KatanaRewardAprData = {
+  katanaAppRewardsAPR?: number
+  fixedRateKatanaRewards?: number
+}
+
+export type KatanaApyBreakdown = {
+  native: number
+  kat: number
+}
+
+function toFiniteNumber(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined
+  const parsed = typeof value === 'string' ? Number(value) : value
+  return typeof parsed === 'number' && Number.isFinite(parsed)
+    ? parsed
+    : undefined
+}
+
+function getKatanaRecordForVault(vault: any, katanaAprs: any | undefined): any {
+  if (!vault?.address || !katanaAprs) return undefined
+
+  const normalized = vault.address.toLowerCase().replace(/^0x/, '')
+  const withPrefix = `0x${normalized}`
+
+  return (
+    katanaAprs[normalized] ||
+    katanaAprs[withPrefix] ||
+    katanaAprs[vault.address] ||
+    katanaAprs[vault.address.toLowerCase()]
   )
+}
+
+export function getKatanaRewardAprData(
+  record: any
+): KatanaRewardAprData | undefined {
+  const extra = record?.apr?.extra
+  if (!extra) return undefined
+
+  const katanaAppRewardsAPR =
+    toFiniteNumber(extra.katanaAppRewardsAPR) ??
+    toFiniteNumber(extra.katanaRewardsAPR)
+  const fixedRateKatanaRewards =
+    toFiniteNumber(extra.fixedRateKatanaRewards) ??
+    toFiniteNumber(extra.FixedRateKatanaRewards)
+
+  if (
+    katanaAppRewardsAPR === undefined &&
+    fixedRateKatanaRewards === undefined
+  ) {
+    return undefined
+  }
+
+  return {
+    katanaAppRewardsAPR,
+    fixedRateKatanaRewards,
+  }
+}
+
+export function hasKatanaRewardAprData(record: any): boolean {
+  return getKatanaRewardAprData(record) !== undefined
+}
+
+function getKatanaRewardAprDataForVault(
+  vault: any,
+  katanaAprs: any | undefined
+): KatanaRewardAprData | undefined {
+  return (
+    getKatanaRewardAprData(vault) ??
+    getKatanaRewardAprData(getKatanaRecordForVault(vault, katanaAprs))
+  )
+}
+
+function calculateKatanaRewardApr(
+  data: KatanaRewardAprData | undefined
+): number {
+  return (data?.katanaAppRewardsAPR || 0) + (data?.fixedRateKatanaRewards || 0)
+}
+
+function getHistoricalBaseAPY(vault: any): number | undefined {
+  if (!vault?.apr?.points) return undefined
+
+  const monthly = toFiniteNumber(vault.apr.points.monthAgo)
+  if (typeof monthly === 'number' && monthly > 0) return monthly
+
+  const weekly = toFiniteNumber(vault.apr.points.weekAgo)
+  if (typeof weekly === 'number') return weekly
+
+  return monthly
+}
+
+export function getKatanaEstimatedApyBreakdown(
+  vault: any,
+  katanaAprs: any | undefined
+): KatanaApyBreakdown | undefined {
+  if (vault?.chainID !== KATANA_CHAIN_ID) return undefined
+
+  const katanaRewardAprData = getKatanaRewardAprDataForVault(vault, katanaAprs)
+  if (!katanaRewardAprData) return undefined
+
+  return {
+    native:
+      toFiniteNumber(vault.apr?.forwardAPR?.netAPR) ??
+      toFiniteNumber(vault.apr?.netAPR) ??
+      0,
+    kat: calculateKatanaRewardApr(katanaRewardAprData),
+  }
+}
+
+export function getKatanaHistoricalApyBreakdown(
+  vault: any,
+  katanaAprs: any | undefined
+): KatanaApyBreakdown | undefined {
+  if (vault?.chainID !== KATANA_CHAIN_ID) return undefined
+
+  const katanaRewardAprData = getKatanaRewardAprDataForVault(vault, katanaAprs)
+  const native = getHistoricalBaseAPY(vault)
+
+  if (!katanaRewardAprData || typeof native !== 'number') return undefined
+
+  return {
+    native,
+    kat: calculateKatanaRewardApr(katanaRewardAprData),
+  }
 }
 
 export function calculateEstimatedAPY(
@@ -26,15 +140,9 @@ export function calculateEstimatedAPY(
   )
     return [yBoldApr.estimatedAPY || 0, undefined]
 
-  if (vault.chainID === 747474 && katanaAprs) {
-    const normalized = vault.address.toLowerCase().replace('0x', '')
-    const withPrefix = `0x${normalized}`
-    const extra =
-      katanaAprs[normalized]?.apr?.extra ||
-      katanaAprs[withPrefix]?.apr?.extra ||
-      katanaAprs[vault.address]?.apr?.extra
-    const katAPY = extra ? calculateKatanaAPY(extra) : 0
-    return [katAPY > 0 ? katAPY : 0, undefined]
+  const katanaEstimatedBreakdown = getKatanaEstimatedApyBreakdown(vault, katanaAprs)
+  if (katanaEstimatedBreakdown) {
+    return [katanaEstimatedBreakdown.native + katanaEstimatedBreakdown.kat, undefined]
   }
 
   const sumRewards =
@@ -48,6 +156,7 @@ export function calculateEstimatedAPY(
 
 export function calculateHistoricalAPY(
   vault: any,
+  katanaAprs: any | undefined,
   yBoldApr: { historicalAPY: number } | null
 ): number {
   if (
@@ -55,9 +164,11 @@ export function calculateHistoricalAPY(
     yBoldApr
   )
     return yBoldApr.historicalAPY
-  if (vault.chainID === 747474) return -1
-  if (!vault?.apr?.points) return 0
-  const monthly = vault.apr.points.monthAgo || 0
-  const weekly = vault.apr.points.weekAgo || 0
-  return monthly > 0 ? monthly : weekly
+
+  const katanaHistoricalBreakdown = getKatanaHistoricalApyBreakdown(vault, katanaAprs)
+  if (katanaHistoricalBreakdown) {
+    return katanaHistoricalBreakdown.native + katanaHistoricalBreakdown.kat
+  }
+
+  return getHistoricalBaseAPY(vault) || 0
 }

--- a/src/lib/og/data.test.ts
+++ b/src/lib/og/data.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  DEFAULT_YEARN_ASSETS_URI,
+  getYearnTokenLogoUrl,
+  normalizeYearnAssetsBaseUrl,
+} from './data'
+
+describe('Yearn asset URL helpers', () => {
+  test('falls back to the default token-assets CDN when no base URL is provided', () => {
+    expect(normalizeYearnAssetsBaseUrl(undefined)).toBe(
+      `${DEFAULT_YEARN_ASSETS_URI}/tokens`
+    )
+  })
+
+  test('upgrades the legacy bare jsdelivr host to the default token-assets CDN', () => {
+    expect(normalizeYearnAssetsBaseUrl('cdn.jsdelivr.net')).toBe(
+      DEFAULT_YEARN_ASSETS_URI
+    )
+    expect(normalizeYearnAssetsBaseUrl('https://cdn.jsdelivr.net')).toBe(
+      DEFAULT_YEARN_ASSETS_URI
+    )
+  })
+
+  test('builds absolute token logo URLs from a root assets base URL', () => {
+    expect(
+      getYearnTokenLogoUrl(
+        747474,
+        '0x80c34BD3A3569E126e7055831036aa7b212cB159',
+        'https://cdn.jsdelivr.net/gh/yearn/tokenassets@main'
+      )
+    ).toBe(
+      'https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/747474/0x80c34bd3a3569e126e7055831036aa7b212cb159/logo-128.png'
+    )
+  })
+
+  test('does not duplicate the tokens segment when the base URL already includes it', () => {
+    expect(
+      getYearnTokenLogoUrl(
+        '1',
+        'AaaFEa48472f77563961Cdb53291DEDfB46F9040',
+        'https://assets.example.com/tokens/'
+      )
+    ).toBe(
+      'https://assets.example.com/tokens/1/0xaaafea48472f77563961cdb53291dedfb46f9040/logo-128.png'
+    )
+  })
+})

--- a/src/lib/og/data.test.ts
+++ b/src/lib/og/data.test.ts
@@ -1,14 +1,26 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
 import {
   DEFAULT_YEARN_ASSETS_URI,
   getYearnTokenLogoUrl,
   normalizeYearnAssetsBaseUrl,
 } from './data'
 
+const ORIGINAL_BASE_YEARN_ASSETS_URI = process.env.BASE_YEARN_ASSETS_URI
+
+afterEach(() => {
+  if (ORIGINAL_BASE_YEARN_ASSETS_URI === undefined) {
+    delete process.env.BASE_YEARN_ASSETS_URI
+  } else {
+    process.env.BASE_YEARN_ASSETS_URI = ORIGINAL_BASE_YEARN_ASSETS_URI
+  }
+})
+
 describe('Yearn asset URL helpers', () => {
   test('falls back to the default token-assets CDN when no base URL is provided', () => {
+    delete process.env.BASE_YEARN_ASSETS_URI
+
     expect(normalizeYearnAssetsBaseUrl(undefined)).toBe(
-      `${DEFAULT_YEARN_ASSETS_URI}/tokens`
+      DEFAULT_YEARN_ASSETS_URI
     )
   })
 

--- a/src/lib/og/data.ts
+++ b/src/lib/og/data.ts
@@ -1,4 +1,6 @@
 export const ALLOWED_CHAIN_IDS = [1, 10, 137, 250, 8453, 42161, 747474]
+export const DEFAULT_YEARN_ASSETS_URI =
+  'https://cdn.jsdelivr.net/gh/yearn/tokenassets@main'
 export const YBOLD_VAULT_ADDRESS = '0x9F4330700a36B29952869fac9b33f45EEdd8A3d8'
 export const YBOLD_STAKING_ADDRESS =
   '0x23346B04a7f55b8760E5860AA5A77383D63491cD'
@@ -63,4 +65,40 @@ export function formatUSD(amount: number): string {
   if (amount < 1e9) return `$${(amount / 1e6).toFixed(2)}M`
   if (amount < 1e12) return `$${(amount / 1e9).toFixed(2)}B`
   return `$${(amount / 1e12).toFixed(1)}T`
+}
+
+export function normalizeYearnAssetsBaseUrl(
+  baseUrl = process.env.BASE_YEARN_ASSETS_URI
+): string {
+  const trimmed = baseUrl?.trim()
+  if (!trimmed) return DEFAULT_YEARN_ASSETS_URI
+
+  const withProtocol = /^https?:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`
+
+  try {
+    const parsed = new URL(withProtocol)
+    if (parsed.hostname === 'cdn.jsdelivr.net' && parsed.pathname === '/') {
+      return DEFAULT_YEARN_ASSETS_URI
+    }
+    return parsed.toString().replace(/\/$/, '')
+  } catch {
+    return DEFAULT_YEARN_ASSETS_URI
+  }
+}
+
+export function getYearnTokenLogoUrl(
+  chainID: string | number,
+  address: string,
+  baseUrl = process.env.BASE_YEARN_ASSETS_URI
+): string {
+  const normalizedBaseUrl = normalizeYearnAssetsBaseUrl(baseUrl)
+  const tokenBaseUrl = /\/tokens?$/.test(normalizedBaseUrl)
+    ? normalizedBaseUrl
+    : `${normalizedBaseUrl}/tokens`
+
+  return `${tokenBaseUrl}/${chainID}/${toComparableEthereumAddress(
+    address
+  )}/logo-128.png`
 }

--- a/src/lib/og/fetchers.test.ts
+++ b/src/lib/og/fetchers.test.ts
@@ -152,6 +152,104 @@ describe('Kong vault snapshot normalization', () => {
     expect(vault?.tvl?.tvl).toBe(10)
   })
 
+  test('falls back to the default Kong REST base URL when the env override is blank', async () => {
+    process.env.KONG_REST_URL = '   '
+
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(
+        'https://kong.yearn.fi/api/rest/snapshot/747474/0x80c34BD3A3569E126e7055831036aa7b212cB159'
+      )
+
+      return {
+        ok: true,
+        json: async () => ({
+          address: '0x80c34BD3A3569E126e7055831036aa7b212cB159',
+          chainId: 747474,
+          name: 'vbUSDC yVault',
+          symbol: 'yvvbUSDC',
+          decimals: 6,
+          asset: {
+            address: '0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36',
+            name: 'Vault Bridge USDC',
+            symbol: 'vbUSDC',
+            decimals: '6',
+          },
+          tvl: { close: 10 },
+          performance: {
+            historical: { net: 0.01, weeklyNet: 0.01, monthlyNet: 0.02, inceptionNet: 0.03 },
+          },
+        }),
+      } as Response
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const vault = await fetchVaultData(
+      '747474',
+      '0x80c34BD3A3569E126e7055831036aa7b212cB159'
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(vault?.name).toBe('vbUSDC yVault')
+  })
+
+  test('falls back to the default yDaemon base URL when the env override is non-https', async () => {
+    delete process.env.KONG_REST_URL
+    process.env.YDAEMON_BASE_URI = 'http://localhost:9999'
+
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === 'https://kong.yearn.fi/api/rest/snapshot/747474/0x80c34BD3A3569E126e7055831036aa7b212cB159') {
+        return {
+          ok: false,
+          status: 403,
+        } as Response
+      }
+
+      if (url === 'https://ydaemon.yearn.fi/747474/vaults/0x80c34BD3A3569E126e7055831036aa7b212cB159') {
+        return {
+          ok: true,
+          json: async () => ({
+            address: '0x80c34BD3A3569E126e7055831036aa7b212cB159',
+            chainID: 747474,
+            name: 'USDC yVault',
+            token: {
+              address: '0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36',
+              name: 'Vault Bridge USDC',
+              symbol: 'vbUSDC',
+              decimals: 6,
+            },
+            tvl: { tvl: 18806547.346547082 },
+            apr: {
+              netAPR: 0.009217438151773116,
+              points: {
+                weekAgo: 0.00860720591038322,
+                monthAgo: 0.009217438151773116,
+              },
+              extra: {},
+              forwardAPR: {
+                netAPR: null,
+              },
+            },
+          }),
+        } as Response
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const vault = await fetchVaultData(
+      '747474',
+      '0x80c34BD3A3569E126e7055831036aa7b212cB159'
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(vault?.name).toBe('USDC yVault')
+  })
+
   test('falls back to yDaemon when Kong snapshot fetching fails', async () => {
     delete process.env.KONG_REST_URL
     delete process.env.YDAEMON_BASE_URI

--- a/src/lib/og/fetchers.test.ts
+++ b/src/lib/og/fetchers.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { fetchVaultData, normalizeKongVaultSnapshot } from './fetchers'
+
+const ORIGINAL_FETCH = global.fetch
+const ORIGINAL_KONG_REST_URL = process.env.KONG_REST_URL
+const ORIGINAL_YDAEMON_BASE_URI = process.env.YDAEMON_BASE_URI
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH
+  if (ORIGINAL_KONG_REST_URL === undefined) {
+    delete process.env.KONG_REST_URL
+  } else {
+    process.env.KONG_REST_URL = ORIGINAL_KONG_REST_URL
+  }
+  if (ORIGINAL_YDAEMON_BASE_URI === undefined) {
+    delete process.env.YDAEMON_BASE_URI
+  } else {
+    process.env.YDAEMON_BASE_URI = ORIGINAL_YDAEMON_BASE_URI
+  }
+})
+
+describe('Kong vault snapshot normalization', () => {
+  test('maps Kong snapshot fields into the OG vault shape for Katana vaults', () => {
+    const normalized = normalizeKongVaultSnapshot({
+      address: '0x80c34BD3A3569E126e7055831036aa7b212cB159',
+      chainId: 747474,
+      name: 'vbUSDC yVault',
+      symbol: 'yvvbUSDC',
+      decimals: 6,
+      asset: {
+        address: '0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36',
+        name: 'Vault Bridge USDC',
+        symbol: 'vbUSDC',
+        decimals: '6',
+      },
+      tvl: {
+        close: 18806574.538983293,
+      },
+      performance: {
+        oracle: {
+          apr: 0.06566843618088732,
+          apy: 0.06782834953930439,
+        },
+        estimated: {
+          type: 'katana-estimated-apr',
+          components: {
+            katanaBonusAPY: 0,
+            katanaAppRewardsAPR: 0.020118608540646715,
+            steerPointsPerDollar: 0.227,
+            fixedRateKatanaRewards: 0.032847499999999995,
+          },
+        },
+        historical: {
+          net: 0.008555529616836255,
+          weeklyNet: 0.008555529616836255,
+          monthlyNet: 0.00921756354738168,
+          inceptionNet: 0.021401895676158356,
+        },
+      },
+    })
+
+    expect(normalized).toEqual({
+      address: '0x80c34BD3A3569E126e7055831036aa7b212cB159',
+      chainID: 747474,
+      name: 'vbUSDC yVault',
+      token: {
+        address: '0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36',
+        name: 'Vault Bridge USDC',
+        symbol: 'vbUSDC',
+        decimals: 6,
+      },
+      tvl: {
+        tvl: 18806574.538983293,
+      },
+      apr: {
+        type: 'katana-estimated-apr',
+        netAPR: 0.008555529616836255,
+        extra: {
+          stakingRewardsAPR: 0,
+          gammaRewardAPR: 0,
+          katanaBonusAPY: 0,
+          katanaAppRewardsAPR: 0.020118608540646715,
+          steerPointsPerDollar: 0.227,
+          fixedRateKatanaRewards: 0.032847499999999995,
+        },
+        points: {
+          weekAgo: 0.008555529616836255,
+          monthAgo: 0.00921756354738168,
+          inception: 0.021401895676158356,
+        },
+        forwardAPR: {
+          type: 'estimated',
+          netAPR: 0.06782834953930439,
+          composite: {
+            boost: 0,
+            poolAPY: 0,
+            boostedAPR: 0,
+            baseAPR: 0,
+            cvxAPR: 0,
+            rewardsAPR: 0,
+            v3OracleCurrentAPR: 0,
+            v3OracleStratRatioAPR: 0,
+            keepCRV: 0,
+            keepVELO: 0,
+            cvxKeepCRV: 0,
+          },
+        },
+      },
+    })
+  })
+
+  test('fetches Kong snapshots from the default REST base URL', async () => {
+    delete process.env.KONG_REST_URL
+
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(
+        'https://kong.yearn.fi/api/rest/snapshot/747474/0x80c34BD3A3569E126e7055831036aa7b212cB159'
+      )
+
+      return {
+        ok: true,
+        json: async () => ({
+          address: '0x80c34BD3A3569E126e7055831036aa7b212cB159',
+          chainId: 747474,
+          name: 'vbUSDC yVault',
+          symbol: 'yvvbUSDC',
+          decimals: 6,
+          asset: {
+            address: '0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36',
+            name: 'Vault Bridge USDC',
+            symbol: 'vbUSDC',
+            decimals: '6',
+          },
+          tvl: { close: 10 },
+          performance: {
+            historical: { net: 0.01, weeklyNet: 0.01, monthlyNet: 0.02, inceptionNet: 0.03 },
+          },
+        }),
+      } as Response
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const vault = await fetchVaultData(
+      '747474',
+      '0x80c34BD3A3569E126e7055831036aa7b212cB159'
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(vault?.name).toBe('vbUSDC yVault')
+    expect(vault?.tvl?.tvl).toBe(10)
+  })
+
+  test('falls back to yDaemon when Kong snapshot fetching fails', async () => {
+    delete process.env.KONG_REST_URL
+    delete process.env.YDAEMON_BASE_URI
+
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === 'https://kong.yearn.fi/api/rest/snapshot/747474/0x80c34BD3A3569E126e7055831036aa7b212cB159') {
+        return {
+          ok: false,
+          status: 403,
+        } as Response
+      }
+
+      if (url === 'https://ydaemon.yearn.fi/747474/vaults/0x80c34BD3A3569E126e7055831036aa7b212cB159') {
+        return {
+          ok: true,
+          json: async () => ({
+            address: '0x80c34BD3A3569E126e7055831036aa7b212cB159',
+            chainID: 747474,
+            name: 'USDC yVault',
+            token: {
+              address: '0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36',
+              name: 'Vault Bridge USDC',
+              symbol: 'vbUSDC',
+              decimals: 6,
+            },
+            tvl: { tvl: 18806547.346547082 },
+            apr: {
+              netAPR: 0.009217438151773116,
+              points: {
+                weekAgo: 0.00860720591038322,
+                monthAgo: 0.009217438151773116,
+              },
+              extra: {},
+              forwardAPR: {
+                netAPR: null,
+              },
+            },
+          }),
+        } as Response
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const vault = await fetchVaultData(
+      '747474',
+      '0x80c34BD3A3569E126e7055831036aa7b212cB159'
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(vault?.name).toBe('USDC yVault')
+    expect(vault?.chainID).toBe(747474)
+    expect(vault?.token.decimals).toBe(6)
+    expect(vault?.tvl?.tvl).toBe(18806547.346547082)
+  })
+})

--- a/src/lib/og/fetchers.test.ts
+++ b/src/lib/og/fetchers.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test'
-import { fetchVaultData, normalizeKongVaultSnapshot } from './fetchers'
+import { fetchVaultData, fetchYBoldApr, normalizeKongVaultSnapshot } from './fetchers'
 
 const ORIGINAL_FETCH = global.fetch
 const ORIGINAL_KONG_REST_URL = process.env.KONG_REST_URL
@@ -40,6 +40,7 @@ describe('Kong vault snapshot normalization', () => {
         oracle: {
           apr: 0.06566843618088732,
           apy: 0.06782834953930439,
+          netAPY: 0.06123456789,
         },
         estimated: {
           type: 'katana-estimated-apr',
@@ -90,7 +91,7 @@ describe('Kong vault snapshot normalization', () => {
         },
         forwardAPR: {
           type: 'estimated',
-          netAPR: 0.06782834953930439,
+          netAPR: 0.06123456789,
           composite: {
             boost: 0,
             poolAPY: 0,
@@ -209,5 +210,167 @@ describe('Kong vault snapshot normalization', () => {
     expect(vault?.chainID).toBe(747474)
     expect(vault?.token.decimals).toBe(6)
     expect(vault?.tvl?.tvl).toBe(18806547.346547082)
+  })
+
+  test('prefers the ysYBOLD staking snapshot oracle netAPY for yBOLD estimated APY', async () => {
+    delete process.env.KONG_REST_URL
+
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(
+        'https://kong.yearn.fi/api/rest/snapshot/1/0x23346B04a7f55b8760E5860AA5A77383D63491cD'
+      )
+
+      return {
+        ok: true,
+        json: async () => ({
+          address: '0x23346B04a7f55b8760E5860AA5A77383D63491cD',
+          chainId: 1,
+          name: 'Staked yBOLD',
+          symbol: 'ysyBOLD',
+          decimals: 18,
+          asset: {
+            address: '0x9F4330700a36B29952869fac9b33f45EEdd8A3d8',
+            name: 'yBOLD',
+            symbol: 'yBOLD',
+            decimals: '18',
+          },
+          apy: {
+            net: 0.04639864387148984,
+          },
+          tvl: { close: 1 },
+          performance: {
+            historical: { net: 0.04639864387148984 },
+            oracle: {
+              netAPY: 0.0344,
+              apy: 0.0355,
+              apr: 0.0349,
+            },
+          },
+        }),
+      } as Response
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const apr = await fetchYBoldApr(
+      '1',
+      '0x23346B04a7f55b8760E5860AA5A77383D63491cD'
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(apr).toEqual({
+      estimatedAPY: 0.0344,
+      historicalAPY: 0.04639864387148984,
+    })
+  })
+
+  test('falls back to the ysYBOLD staking snapshot oracle APY when netAPY is unavailable', async () => {
+    delete process.env.KONG_REST_URL
+
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(
+        'https://kong.yearn.fi/api/rest/snapshot/1/0x23346B04a7f55b8760E5860AA5A77383D63491cD'
+      )
+
+      return {
+        ok: true,
+        json: async () => ({
+          address: '0x23346B04a7f55b8760E5860AA5A77383D63491cD',
+          chainId: 1,
+          name: 'Staked yBOLD',
+          symbol: 'ysyBOLD',
+          decimals: 18,
+          asset: {
+            address: '0x9F4330700a36B29952869fac9b33f45EEdd8A3d8',
+            name: 'yBOLD',
+            symbol: 'yBOLD',
+            decimals: '18',
+          },
+          apy: {
+            net: 0.04639864387148984,
+          },
+          tvl: { close: 1 },
+          performance: {
+            historical: { net: 0.04639864387148984 },
+            oracle: {
+              apy: 0.0355,
+              apr: 0.0349,
+            },
+          },
+        }),
+      } as Response
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const apr = await fetchYBoldApr(
+      '1',
+      '0x23346B04a7f55b8760E5860AA5A77383D63491cD'
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(apr).toEqual({
+      estimatedAPY: 0.0355,
+      historicalAPY: 0.04639864387148984,
+    })
+  })
+
+  test('falls back to yDaemon APR values for yBOLD when Kong is unavailable', async () => {
+    delete process.env.KONG_REST_URL
+    delete process.env.YDAEMON_BASE_URI
+
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === 'https://kong.yearn.fi/api/rest/snapshot/1/0x23346B04a7f55b8760E5860AA5A77383D63491cD') {
+        return {
+          ok: false,
+          status: 403,
+        } as Response
+      }
+
+      if (url === 'https://ydaemon.yearn.fi/1/vaults/0x23346B04a7f55b8760E5860AA5A77383D63491cD') {
+        return {
+          ok: true,
+          json: async () => ({
+            address: '0x23346B04a7f55b8760E5860AA5A77383D63491cD',
+            chainID: 1,
+            name: 'Staked yBOLD',
+            token: {
+              address: '0x9F4330700a36B29952869fac9b33f45EEdd8A3d8',
+              name: 'yBOLD',
+              symbol: 'yBOLD',
+              decimals: 18,
+            },
+            apr: {
+              netAPR: 0.04639864387148984,
+              points: {
+                weekAgo: 0.0549088591759741,
+                monthAgo: 0.04639864387148984,
+              },
+              extra: {},
+              forwardAPR: {
+                netAPR: null,
+              },
+            },
+          }),
+        } as Response
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const apr = await fetchYBoldApr(
+      '1',
+      '0x23346B04a7f55b8760E5860AA5A77383D63491cD'
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(apr).toEqual({
+      estimatedAPY: 0.04639864387148984,
+      historicalAPY: 0.04639864387148984,
+    })
   })
 })

--- a/src/lib/og/fetchers.ts
+++ b/src/lib/og/fetchers.ts
@@ -17,12 +17,27 @@ function pickNumber(...values: unknown[]): number {
   return 0
 }
 
+function normalizeHttpsBaseUrl(rawValue: string | undefined, fallback: string): string {
+  const normalizedFallback = fallback.replace(/\/+$/, '')
+  const candidate = rawValue?.trim()
+
+  if (!candidate) return normalizedFallback
+
+  try {
+    const parsed = new URL(candidate)
+    if (parsed.protocol !== 'https:') return normalizedFallback
+    return parsed.toString().replace(/\/+$/, '')
+  } catch {
+    return normalizedFallback
+  }
+}
+
 function getKongRestBaseUrl(): string {
-  return (process.env.KONG_REST_URL || DEFAULT_KONG_REST_URL).replace(/\/$/, '')
+  return normalizeHttpsBaseUrl(process.env.KONG_REST_URL, DEFAULT_KONG_REST_URL)
 }
 
 function getYDaemonBaseUrl(): string {
-  return (process.env.YDAEMON_BASE_URI || DEFAULT_YDAEMON_BASE_URL).replace(/\/$/, '')
+  return normalizeHttpsBaseUrl(process.env.YDAEMON_BASE_URI, DEFAULT_YDAEMON_BASE_URL)
 }
 
 async function fetchKongVaultSnapshot(

--- a/src/lib/og/fetchers.ts
+++ b/src/lib/og/fetchers.ts
@@ -1,3 +1,30 @@
+const DEFAULT_KONG_REST_URL = 'https://kong.yearn.fi/api/rest'
+const DEFAULT_YDAEMON_BASE_URL = 'https://ydaemon.yearn.fi'
+
+function toFiniteNumber(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined
+  const parsed = typeof value === 'string' ? Number(value) : value
+  return typeof parsed === 'number' && Number.isFinite(parsed)
+    ? parsed
+    : undefined
+}
+
+function pickNumber(...values: unknown[]): number {
+  for (const value of values) {
+    const parsed = toFiniteNumber(value)
+    if (typeof parsed === 'number') return parsed
+  }
+  return 0
+}
+
+function getKongRestBaseUrl(): string {
+  return (process.env.KONG_REST_URL || DEFAULT_KONG_REST_URL).replace(/\/$/, '')
+}
+
+function getYDaemonBaseUrl(): string {
+  return (process.env.YDAEMON_BASE_URI || DEFAULT_YDAEMON_BASE_URL).replace(/\/$/, '')
+}
+
 async function fetchJson(
   url: string,
   headers?: Record<string, string>
@@ -17,12 +44,122 @@ async function fetchJson(
   }
 }
 
+function normalizeYDaemonVault(vault: any): any | null {
+  if (!vault?.address) return null
+
+  const chainID = pickNumber(vault.chainID, vault.chainId)
+  if (!chainID) return null
+
+  return {
+    ...vault,
+    chainID,
+    token: vault.token
+      ? {
+          ...vault.token,
+          decimals: pickNumber(vault.token.decimals, vault.decimals, 18),
+        }
+      : {
+          address: vault.address,
+          name: vault.name || 'Vault Token',
+          symbol: vault.symbol || '',
+          decimals: pickNumber(vault.decimals, 18),
+        },
+  }
+}
+
+export function normalizeKongVaultSnapshot(snapshot: any): any | null {
+  if (!snapshot?.address || !snapshot?.chainId) return null
+
+  const asset = snapshot.asset
+  const historical = snapshot.performance?.historical
+  const oracle = snapshot.performance?.oracle
+  const estimated = snapshot.performance?.estimated
+  const estimatedComponents = estimated?.components
+  const isKatanaVault = snapshot.chainId === 747474
+
+  const fixedRateKatanaRewards =
+    toFiniteNumber(estimatedComponents?.fixedRateKatanaRewards) ??
+    toFiniteNumber(estimatedComponents?.FixedRateKatanaRewards) ??
+    0
+
+  const forwardNetAPR = isKatanaVault
+    ? pickNumber(
+        oracle?.apy,
+        oracle?.apr,
+        estimated?.apy,
+        estimated?.apr,
+        historical?.net
+      )
+    : pickNumber(
+        estimated?.apy,
+        estimated?.apr,
+        oracle?.apy,
+        oracle?.apr,
+        historical?.net
+      )
+
+  return {
+    address: snapshot.address,
+    chainID: snapshot.chainId,
+    name: snapshot.name || snapshot.meta?.name || snapshot.meta?.displayName || '',
+    token: {
+      address: asset?.address || snapshot.address,
+      name: asset?.name || snapshot.name || 'Vault Token',
+      symbol: asset?.symbol || snapshot.symbol || '',
+      decimals: pickNumber(asset?.decimals, snapshot.decimals, 18),
+    },
+    tvl: {
+      tvl: pickNumber(snapshot.tvl?.close),
+    },
+    apr: {
+      type:
+        snapshot.apy?.label ||
+        estimated?.type ||
+        (oracle?.apy !== null && oracle?.apy !== undefined ? 'oracle' : 'unknown'),
+      netAPR: pickNumber(snapshot.apy?.net, historical?.net),
+      extra: {
+        stakingRewardsAPR: 0,
+        gammaRewardAPR: 0,
+        katanaBonusAPY: pickNumber(estimatedComponents?.katanaBonusAPY),
+        katanaAppRewardsAPR: pickNumber(estimatedComponents?.katanaAppRewardsAPR),
+        steerPointsPerDollar: pickNumber(estimatedComponents?.steerPointsPerDollar),
+        fixedRateKatanaRewards,
+      },
+      points: {
+        weekAgo: pickNumber(snapshot.apy?.weeklyNet, historical?.weeklyNet),
+        monthAgo: pickNumber(snapshot.apy?.monthlyNet, historical?.monthlyNet),
+        inception: pickNumber(snapshot.apy?.inceptionNet, historical?.inceptionNet),
+      },
+      forwardAPR: {
+        type: estimated ? 'estimated' : oracle ? 'oracle' : '',
+        netAPR: forwardNetAPR,
+        composite: {
+          boost: 0,
+          poolAPY: 0,
+          boostedAPR: 0,
+          baseAPR: 0,
+          cvxAPR: 0,
+          rewardsAPR: 0,
+          v3OracleCurrentAPR: 0,
+          v3OracleStratRatioAPR: 0,
+          keepCRV: 0,
+          keepVELO: 0,
+          cvxKeepCRV: 0,
+        },
+      },
+    },
+  }
+}
+
 export async function fetchVaultData(chainID: string, address: string) {
-  const baseUri = process.env.YDAEMON_BASE_URI
-  if (!baseUri || !baseUri.startsWith('https://')) return null
-  return fetchJson(
-    `${baseUri}/${chainID}/vault/${address}?strategiesDetails=withDetails&strategiesCondition=inQueue`
-  )
+  const kongBaseUrl = getKongRestBaseUrl()
+  const snapshot = await fetchJson(`${kongBaseUrl}/snapshot/${chainID}/${address}`)
+  const normalizedSnapshot = normalizeKongVaultSnapshot(snapshot)
+  if (normalizedSnapshot) return normalizedSnapshot
+
+  const yDaemonBaseUrl = getYDaemonBaseUrl()
+  const vault = await fetchJson(`${yDaemonBaseUrl}/${chainID}/vaults/${address}`)
+  return normalizeYDaemonVault(vault)
 }
 
 export async function fetchKatanaAprs(): Promise<any | null> {
@@ -45,11 +182,7 @@ export async function fetchYBoldApr(
   stakingAddress: string
 ): Promise<{ estimatedAPY: number; historicalAPY: number } | null> {
   if (chainID !== '1') return null
-  const baseUri = process.env.YDAEMON_BASE_URI
-  if (!baseUri || !baseUri.startsWith('https://')) return null
-  const st = await fetchJson(
-    `${baseUri}/${chainID}/vault/${stakingAddress}?strategiesDetails=withDetails&strategiesCondition=inQueue`
-  )
+  const st = await fetchVaultData(chainID, stakingAddress)
   if (!st?.apr) return null
   return {
     estimatedAPY: st.apr.forwardAPR?.netAPR || st.apr.netAPR || 0,

--- a/src/lib/og/fetchers.ts
+++ b/src/lib/og/fetchers.ts
@@ -25,6 +25,22 @@ function getYDaemonBaseUrl(): string {
   return (process.env.YDAEMON_BASE_URI || DEFAULT_YDAEMON_BASE_URL).replace(/\/$/, '')
 }
 
+async function fetchKongVaultSnapshot(
+  chainID: string,
+  address: string
+): Promise<any | null> {
+  const kongBaseUrl = getKongRestBaseUrl()
+  return fetchJson(`${kongBaseUrl}/snapshot/${chainID}/${address}`)
+}
+
+async function fetchYDaemonVault(
+  chainID: string,
+  address: string
+): Promise<any | null> {
+  const yDaemonBaseUrl = getYDaemonBaseUrl()
+  return fetchJson(`${yDaemonBaseUrl}/${chainID}/vaults/${address}`)
+}
+
 async function fetchJson(
   url: string,
   headers?: Record<string, string>
@@ -84,6 +100,7 @@ export function normalizeKongVaultSnapshot(snapshot: any): any | null {
 
   const forwardNetAPR = isKatanaVault
     ? pickNumber(
+        oracle?.netAPY,
         oracle?.apy,
         oracle?.apr,
         estimated?.apy,
@@ -93,6 +110,7 @@ export function normalizeKongVaultSnapshot(snapshot: any): any | null {
     : pickNumber(
         estimated?.apy,
         estimated?.apr,
+        oracle?.netAPY,
         oracle?.apy,
         oracle?.apr,
         historical?.net
@@ -115,7 +133,10 @@ export function normalizeKongVaultSnapshot(snapshot: any): any | null {
       type:
         snapshot.apy?.label ||
         estimated?.type ||
-        (oracle?.apy !== null && oracle?.apy !== undefined ? 'oracle' : 'unknown'),
+        ((oracle?.netAPY !== null && oracle?.netAPY !== undefined) ||
+        (oracle?.apy !== null && oracle?.apy !== undefined)
+          ? 'oracle'
+          : 'unknown'),
       netAPR: pickNumber(snapshot.apy?.net, historical?.net),
       extra: {
         stakingRewardsAPR: 0,
@@ -152,13 +173,11 @@ export function normalizeKongVaultSnapshot(snapshot: any): any | null {
 }
 
 export async function fetchVaultData(chainID: string, address: string) {
-  const kongBaseUrl = getKongRestBaseUrl()
-  const snapshot = await fetchJson(`${kongBaseUrl}/snapshot/${chainID}/${address}`)
+  const snapshot = await fetchKongVaultSnapshot(chainID, address)
   const normalizedSnapshot = normalizeKongVaultSnapshot(snapshot)
   if (normalizedSnapshot) return normalizedSnapshot
 
-  const yDaemonBaseUrl = getYDaemonBaseUrl()
-  const vault = await fetchJson(`${yDaemonBaseUrl}/${chainID}/vaults/${address}`)
+  const vault = await fetchYDaemonVault(chainID, address)
   return normalizeYDaemonVault(vault)
 }
 
@@ -182,7 +201,25 @@ export async function fetchYBoldApr(
   stakingAddress: string
 ): Promise<{ estimatedAPY: number; historicalAPY: number } | null> {
   if (chainID !== '1') return null
-  const st = await fetchVaultData(chainID, stakingAddress)
+
+  const stakingSnapshot = await fetchKongVaultSnapshot(chainID, stakingAddress)
+  const normalizedStakingSnapshot = normalizeKongVaultSnapshot(stakingSnapshot)
+  if (normalizedStakingSnapshot?.apr) {
+    const estimatedAPY =
+      toFiniteNumber(stakingSnapshot?.performance?.oracle?.netAPY) ??
+      toFiniteNumber(stakingSnapshot?.performance?.oracle?.apy) ??
+      toFiniteNumber(stakingSnapshot?.performance?.oracle?.apr) ??
+      toFiniteNumber(normalizedStakingSnapshot.apr.forwardAPR?.netAPR) ??
+      toFiniteNumber(normalizedStakingSnapshot.apr.netAPR) ??
+      0
+
+    return {
+      estimatedAPY,
+      historicalAPY: normalizedStakingSnapshot.apr.netAPR || 0,
+    }
+  }
+
+  const st = normalizeYDaemonVault(await fetchYDaemonVault(chainID, stakingAddress))
   if (!st?.apr) return null
   return {
     estimatedAPY: st.apr.forwardAPR?.netAPR || st.apr.netAPR || 0,

--- a/src/lib/og/fetchers.ts
+++ b/src/lib/og/fetchers.ts
@@ -1,13 +1,7 @@
+import { toFiniteNumber } from './number'
+
 const DEFAULT_KONG_REST_URL = 'https://kong.yearn.fi/api/rest'
 const DEFAULT_YDAEMON_BASE_URL = 'https://ydaemon.yearn.fi'
-
-function toFiniteNumber(value: unknown): number | undefined {
-  if (value === null || value === undefined || value === '') return undefined
-  const parsed = typeof value === 'string' ? Number(value) : value
-  return typeof parsed === 'number' && Number.isFinite(parsed)
-    ? parsed
-    : undefined
-}
 
 function pickNumber(...values: unknown[]): number {
   for (const value of values) {

--- a/src/lib/og/number.ts
+++ b/src/lib/og/number.ts
@@ -1,0 +1,7 @@
+export function toFiniteNumber(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined
+  const parsed = typeof value === 'string' ? Number(value) : value
+  return typeof parsed === 'number' && Number.isFinite(parsed)
+    ? parsed
+    : undefined
+}

--- a/src/lib/og/render.tsx
+++ b/src/lib/og/render.tsx
@@ -72,9 +72,11 @@ export function renderVaultOG(
     icon: string
     name: string
     estimatedApy: string
+    estimatedApyBreakdown?: string
     rewardsAPR?: string
     minBoost?: string
     historicalApy: string
+    historicalApyBreakdown?: string
     tvlUsd: string
     chainName: string
     address: string
@@ -92,6 +94,13 @@ export function renderVaultOG(
     6,
   )}...${data.address.slice(-4)}`
   const earnWithYearnText = brand.cta
+  const hasInlineApyBreakdown = Boolean(
+    data.estimatedApyBreakdown || data.historicalApyBreakdown,
+  )
+  const metricsWidth = hasInlineApyBreakdown ? 760 : 500
+  const metricLabelWidth = 250
+  const metricMainValueWidth = 170
+  const metricBreakdownWidth = hasInlineApyBreakdown ? 300 : 0
   return new ImageResponse(
     <div
       style={{
@@ -221,7 +230,7 @@ export function renderVaultOG(
               {/* Metrics */}
               <div
                 style={{
-                  width: 500,
+                  width: metricsWidth,
                   flexDirection: 'column',
                   justifyContent: 'flex-start',
                   alignItems: 'flex-start',
@@ -232,9 +241,12 @@ export function renderVaultOG(
                 <div
                   style={{
                     alignSelf: 'stretch',
-                    justifyContent: 'space-between',
+                    justifyContent: hasInlineApyBreakdown
+                      ? 'flex-start'
+                      : 'space-between',
                     alignItems: 'center',
                     display: 'flex',
+                    gap: hasInlineApyBreakdown ? 20 : 0,
                   }}
                 >
                   <div
@@ -243,6 +255,9 @@ export function renderVaultOG(
                       flexDirection: 'column',
                       alignItems: 'flex-start',
                       marginTop: data.rewardsAPR ? '20px' : '0px',
+                      ...(hasInlineApyBreakdown
+                        ? { width: metricLabelWidth, flexShrink: 0 }
+                        : {}),
                     }}
                   >
                     <div
@@ -280,21 +295,54 @@ export function renderVaultOG(
                     style={{
                       display: 'flex',
                       flexDirection: 'column',
-                      alignItems: 'flex-end',
+                      alignItems: hasInlineApyBreakdown ? 'flex-start' : 'flex-end',
                       marginTop: data.rewardsAPR ? '10px' : '0px',
+                      ...(!hasInlineApyBreakdown ? { flex: '1 1 0' } : {}),
                     }}
                   >
                     <div
                       style={{
-                        textAlign: 'right',
-                        color: 'white',
-                        fontSize: 48,
-                        fontFamily: 'Aeonik',
-                        fontWeight: '700',
-                        wordWrap: 'break-word',
+                        display: 'flex',
+                        alignItems: 'flex-end',
+                        justifyContent: hasInlineApyBreakdown
+                          ? 'flex-start'
+                          : 'flex-end',
+                        gap: 14,
+                        whiteSpace: 'nowrap',
                       }}
                     >
-                      {data.estimatedApy}
+                      <div
+                        style={{
+                          textAlign: 'right',
+                          color: 'white',
+                          fontSize: 48,
+                          fontFamily: 'Aeonik',
+                          fontWeight: '700',
+                          wordWrap: 'break-word',
+                          ...(hasInlineApyBreakdown
+                            ? { width: metricMainValueWidth, flexShrink: 0 }
+                            : {}),
+                        }}
+                      >
+                        {data.estimatedApy}
+                      </div>
+                      {data.estimatedApyBreakdown && (
+                        <div
+                          style={{
+                            textAlign: 'right',
+                            color: 'rgba(255, 255, 255, 0.82)',
+                            fontSize: 22,
+                            fontFamily: 'Aeonik',
+                            fontWeight: '400',
+                            whiteSpace: 'nowrap',
+                            marginBottom: 6,
+                            width: metricBreakdownWidth,
+                            flexShrink: 0,
+                          }}
+                        >
+                          {data.estimatedApyBreakdown}
+                        </div>
+                      )}
                     </div>
                     {data.rewardsAPR && (
                       <div
@@ -338,9 +386,12 @@ export function renderVaultOG(
                 <div
                   style={{
                     alignSelf: 'stretch',
-                    justifyContent: 'space-between',
+                    justifyContent: hasInlineApyBreakdown
+                      ? 'flex-start'
+                      : 'space-between',
                     alignItems: 'center',
                     display: 'flex',
+                    gap: hasInlineApyBreakdown ? 20 : 0,
                   }}
                 >
                   <div
@@ -351,31 +402,68 @@ export function renderVaultOG(
                       fontFamily: 'Aeonik',
                       fontWeight: '300',
                       wordWrap: 'break-word',
+                      ...(hasInlineApyBreakdown
+                        ? { width: metricLabelWidth, flexShrink: 0 }
+                        : {}),
                     }}
                   >
                     30-Day APY:
                   </div>
                   <div
                     style={{
-                      alignSelf: 'stretch',
-                      textAlign: 'right',
-                      color: 'white',
-                      fontSize: 32,
-                      fontFamily: 'Aeonik',
-                      fontWeight: '300',
-                      wordWrap: 'break-word',
+                      display: 'flex',
+                      alignItems: 'flex-end',
+                      justifyContent: hasInlineApyBreakdown
+                        ? 'flex-start'
+                        : 'flex-end',
+                      gap: 12,
+                      whiteSpace: 'nowrap',
                     }}
                   >
-                    {data.historicalApy}
+                    <div
+                      style={{
+                        textAlign: 'right',
+                        color: 'white',
+                        fontSize: 32,
+                        fontFamily: 'Aeonik',
+                        fontWeight: '300',
+                        wordWrap: 'break-word',
+                        ...(hasInlineApyBreakdown
+                          ? { width: metricMainValueWidth, flexShrink: 0 }
+                          : {}),
+                      }}
+                    >
+                      {data.historicalApy}
+                    </div>
+                    {data.historicalApyBreakdown && (
+                      <div
+                        style={{
+                          textAlign: 'right',
+                          color: 'rgba(255, 255, 255, 0.82)',
+                          fontSize: 22,
+                          fontFamily: 'Aeonik',
+                          fontWeight: '400',
+                          whiteSpace: 'nowrap',
+                          marginBottom: 3,
+                          width: metricBreakdownWidth,
+                          flexShrink: 0,
+                        }}
+                      >
+                        {data.historicalApyBreakdown}
+                      </div>
+                    )}
                   </div>
                 </div>
 
                 <div
                   style={{
                     alignSelf: 'stretch',
-                    justifyContent: 'space-between',
+                    justifyContent: hasInlineApyBreakdown
+                      ? 'flex-start'
+                      : 'space-between',
                     alignItems: 'center',
                     display: 'flex',
+                    gap: hasInlineApyBreakdown ? 20 : 0,
                   }}
                 >
                   <div
@@ -386,31 +474,46 @@ export function renderVaultOG(
                       fontFamily: 'Aeonik',
                       fontWeight: '300',
                       wordWrap: 'break-word',
+                      ...(hasInlineApyBreakdown
+                        ? { width: metricLabelWidth, flexShrink: 0 }
+                        : {}),
                     }}
                   >
                     Vault TVL:
                   </div>
                   <div
                     style={{
-                      flexDirection: 'column',
-                      justifyContent: 'flex-end',
-                      alignItems: 'flex-end',
                       display: 'flex',
+                      alignItems: 'flex-end',
+                      justifyContent: hasInlineApyBreakdown
+                        ? 'flex-start'
+                        : 'flex-end',
+                      gap: 12,
                     }}
                   >
                     <div
                       style={{
-                        alignSelf: 'stretch',
                         textAlign: 'right',
                         color: 'white',
                         fontSize: 32,
                         fontFamily: 'Aeonik',
                         fontWeight: '300',
                         wordWrap: 'break-word',
+                        ...(hasInlineApyBreakdown
+                          ? { width: metricMainValueWidth, flexShrink: 0 }
+                          : {}),
                       }}
                     >
                       {data.tvlUsd}
                     </div>
+                    {hasInlineApyBreakdown && (
+                      <div
+                        style={{
+                          width: metricBreakdownWidth,
+                          flexShrink: 0,
+                        }}
+                      />
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/lib/og/vaultData.ts
+++ b/src/lib/og/vaultData.ts
@@ -1,7 +1,14 @@
-import { calculateEstimatedAPY, calculateHistoricalAPY } from './apy'
+import {
+  calculateEstimatedAPY,
+  calculateHistoricalAPY,
+  getKatanaEstimatedApyBreakdown,
+  getKatanaHistoricalApyBreakdown,
+  hasKatanaRewardAprData,
+} from './apy'
 import {
   formatUSD,
   getChainName,
+  getYearnTokenLogoUrl,
   YBOLD_STAKING_ADDRESS,
   YBOLD_VAULT_ADDRESS,
 } from './data'
@@ -11,12 +18,25 @@ export type StandardVaultOGData = {
   icon: string
   name: string
   estimatedApy: string
+  estimatedApyBreakdown?: string
   rewardsAPR?: string
   minBoost?: string
   historicalApy: string
+  historicalApyBreakdown?: string
   tvlUsd: string
   chainName: string
   address: string
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(2)}%`
+}
+
+function formatKatanaApyBreakdown(
+  native: number,
+  kat: number
+): string {
+  return `(${formatPercent(native)} native, ${formatPercent(kat)} KAT)`
 }
 
 export async function resolveStandardVaultOGData(
@@ -25,7 +45,9 @@ export async function resolveStandardVaultOGData(
 ): Promise<StandardVaultOGData> {
   const vault = await fetchVaultData(chainID, address)
   let katanaAprs: any | null = null
-  if (chainID === '747474') katanaAprs = await fetchKatanaAprs()
+  if (chainID === '747474' && vault && !hasKatanaRewardAprData(vault)) {
+    katanaAprs = await fetchKatanaAprs()
+  }
   let yBoldApr: { estimatedAPY: number; historicalAPY: number } | null = null
   if (address.toLowerCase() === YBOLD_VAULT_ADDRESS.toLowerCase()) {
     yBoldApr = await fetchYBoldApr(chainID, YBOLD_STAKING_ADDRESS)
@@ -37,16 +59,34 @@ export async function resolveStandardVaultOGData(
       katanaAprs || undefined,
       yBoldApr
     )
-    const hist = calculateHistoricalAPY(vault, yBoldApr)
+    const hist = calculateHistoricalAPY(vault, katanaAprs || undefined, yBoldApr)
+    const estimatedKatanaBreakdown = getKatanaEstimatedApyBreakdown(
+      vault,
+      katanaAprs || undefined
+    )
+    const historicalKatanaBreakdown = getKatanaHistoricalApyBreakdown(
+      vault,
+      katanaAprs || undefined
+    )
     return {
-      icon: `${
-        process.env.BASE_YEARN_ASSETS_URI
-      }/${chainID}/${vault.token.address.toLowerCase()}/logo-128.png`,
+      icon: getYearnTokenLogoUrl(chainID, vault.token.address),
       name: vault.name?.replace(/\s+Vault$/, '') || 'Yearn Vault',
       estimatedApy: `${(underlyingAPY * 100).toFixed(2)}%`,
+      estimatedApyBreakdown: estimatedKatanaBreakdown
+        ? formatKatanaApyBreakdown(
+            estimatedKatanaBreakdown.native,
+            estimatedKatanaBreakdown.kat
+          )
+        : undefined,
       rewardsAPR: rewardsAPR ? `${(rewardsAPR * 100).toFixed(2)}%` : undefined,
       minBoost: rewardsAPR ? `${(rewardsAPR * 10).toFixed(2)}%` : undefined,
-      historicalApy: hist === -1 ? '--%' : `${(hist * 100).toFixed(2)}%`,
+      historicalApy: `${(hist * 100).toFixed(2)}%`,
+      historicalApyBreakdown: historicalKatanaBreakdown
+        ? formatKatanaApyBreakdown(
+            historicalKatanaBreakdown.native,
+            historicalKatanaBreakdown.kat
+          )
+        : undefined,
       tvlUsd: formatUSD(vault.tvl?.tvl || 0),
       chainName: getChainName(parseInt(chainID, 10)),
       address,
@@ -54,9 +94,7 @@ export async function resolveStandardVaultOGData(
   }
 
   return {
-    icon: `${
-      process.env.BASE_YEARN_ASSETS_URI
-    }/${chainID}/${address.toLowerCase()}/logo-128.png`,
+    icon: getYearnTokenLogoUrl(chainID, address),
     name: 'Yearn Vault',
     estimatedApy: '0.00%',
     historicalApy: '0.00%',

--- a/src/lib/og/yvusd.ts
+++ b/src/lib/og/yvusd.ts
@@ -7,6 +7,7 @@ import {
   YVUSD_UNLOCKED_ADDRESS,
 } from './data'
 import { fetchVaultData, fetchYvUsdAprs } from './fetchers'
+import { toFiniteNumber } from './number'
 
 type YvUsdAprServiceVault = {
   address?: string
@@ -42,15 +43,7 @@ export type YvUsdOGData = {
   address: string
 }
 
-function toFiniteNumber(
-  value: number | string | null | undefined,
-): number | null {
-  if (value === null || value === undefined) return null
-  const parsed = typeof value === 'string' ? Number(value) : value
-  return Number.isFinite(parsed) ? parsed : null
-}
-
-function toNonNegativeNumber(value: number | null | undefined): number {
+function toNonNegativeNumber(value: number | undefined): number {
   if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0)
     return 0
   return value


### PR DESCRIPTION
Katana OG cards did not show KAT rewards. This change updates them to get that data from kong and display it.


<img width="1222" height="651" alt="image" src="https://github.com/user-attachments/assets/8c176aab-bc96-4cc7-9e54-7e897f1b7fe4" />
